### PR TITLE
factor out priors for state assignment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - linux
 julia:
   - release
+  - 0.7
   - nightly
 notifications:
   email: false
@@ -15,6 +16,8 @@ git:
 matrix:
   allow_failures:
     - julia: nightly
+      os: linux
+    - julia: 0.7
       os: linux
 
 ## uncomment and modify the following lines to manually install system packages

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,6 +3,6 @@ ArgCheck
 StatsBase
 StatsFuns
 Distributions
-ConjugatePriors 0.2.1
+ConjugatePriors 0.2.3
 ProgressMeter
 Distances

--- a/src/Particles.jl
+++ b/src/Particles.jl
@@ -49,6 +49,7 @@ macro debug(msg)
 end
 
 include("component.jl")
+include("statepriors.jl")
 include("particle.jl")
 include("filters.jl")
 include("fearnhead.jl")

--- a/src/Particles.jl
+++ b/src/Particles.jl
@@ -24,6 +24,8 @@ export
     NormalInverseChisq,
     GibbsCRP,
     GibbsCRPSamples,
+    ChineseRestaurantProcess,
+    StickyCRP,
     fit,
     fit!,
     putatives,

--- a/src/chenliu.jl
+++ b/src/chenliu.jl
@@ -24,8 +24,8 @@ end
 # doens't benefit from redundancy in the same way as the Fearnhead method does
 ChenLiuParticles(n::Int, priors::Union{Tuple,<:Distribution}...; rejuv::Float64=50.) =
     ChenLiuParticles([Particle(priors...) for _ in 1:n], n, rejuv)
-ChenLiuParticles(n::Int, prior::Union{Tuple,<:Distribution}, α::Float64; rejuv::Float64=50.) =
-    ChenLiuParticles([InfiniteParticle(prior, α) for _ in 1:n], n, rejuv)
+ChenLiuParticles(n::Int, prior::Union{Tuple,<:Distribution}, stateprior::T; rejuv::Float64=50.) where T<:StatePrior =
+    ChenLiuParticles([InfiniteParticle(prior, stateprior) for _ in 1:n], n, rejuv)
 
 function propogate_chenliu(p::P, y) where P<:AbstractParticle
     ps = collect(putatives(p, y))

--- a/src/filters.jl
+++ b/src/filters.jl
@@ -3,9 +3,10 @@ using Distances
 
 abstract type ParticleFilter end
 
-function Base.filter!(ps::ParticleFilter, ys::AbstractVector{T} where T, progress=true)
+function Base.filter!(ps::ParticleFilter, ys::AbstractVector{T} where T, progress=true; cb=(ps,y)->nothing)
     @showprogress (progress ? 1 : Inf) "Fitting particles..." for y in ys
         fit!(ps, y)
+        cb(ps, y)
     end
     ps
 end

--- a/src/gibbs.jl
+++ b/src/gibbs.jl
@@ -1,3 +1,5 @@
+# TODO: use StatePrior here, too.
+
 # a gibbs sampler to compare.
 
 # general algorithm:

--- a/src/particle.jl
+++ b/src/particle.jl
@@ -127,8 +127,12 @@ incorporating ``y``: ``\frac{p(y_{x_i=x}, y_{n+1})}{p(y_{x_i=x})}``.
 
 """
 function fit(p::InfiniteParticle, y, x::Int)
+    # first calculate log-prior
+    Δlogweight = log_prior(p.stateprior, x)
+    # then update sufficient stats and convert x to an index
+    stateprior, x = add(p.stateprior, x)
     @argcheck 0 < x ≤ length(p.components)+1
-    Δlogweight = 0
+
     components = copy(p.components)
     if x ≤ length(components)
         # likelihood adjustment for old observations
@@ -136,9 +140,7 @@ function fit(p::InfiniteParticle, y, x::Int)
     else
         push!(components, Component(p.prior))
     end
-    Δlogweight += log_prior(p.stateprior, x)
     components[x] = add(components[x], y)
-    stateprior = add(p.stateprior, x)
     # likelihood of new observation
     Δlogweight += marginal_log_lhood(components[x])
     weight = exp(log(p.weight) + Δlogweight)

--- a/src/particle.jl
+++ b/src/particle.jl
@@ -86,8 +86,10 @@ Base.showcompact(io::IO, p::InfiniteParticle) =
     print(io, "$(length(p.components))+ Particle")
 
 InfiniteParticle(prior::Component, α::Float64) =
-    InfiniteParticle(typeof(prior)[], nothing, 0, 1.0, prior, ChineseRestaurantProcess(α))
-InfiniteParticle(prior, α::Float64) = InfiniteParticle(Component(prior), α)
+    InfiniteParticle(prior, ChineseRestaurantProcess(α))
+InfiniteParticle(prior::Component, stateprior::T) where T<:StatePrior =
+    InfiniteParticle(typeof(prior)[], nothing, 0, 1.0, prior, stateprior)
+InfiniteParticle(prior, stateprior) = InfiniteParticle(Component(prior), stateprior)
 
 weight(p::InfiniteParticle, w::Float64) =
     InfiniteParticle(p.components, p.ancestor, p.assignment, w, p.prior, p.stateprior)

--- a/src/statepriors.jl
+++ b/src/statepriors.jl
@@ -65,7 +65,7 @@ struct StickyCRP <: StatePrior
     Nsame::Vector{Float64}      # number of transitions to same state (sticky or not)
 end    
 
-StickyCRP(α::Float64, κ::Float64) = StickyCRP(α, κ, 0, Vector{Float64}(), Vector{Float64}())
+StickyCRP(α::Float64, κ::Float64) = StickyCRP(α, κ, 1, Vector{Float64}(), Vector{Float64}())
 
 candidates(crp::StickyCRP) = 0:length(crp.N)+1
 add(crp::StickyCRP, x::Int, n::Float64=1.0) = add(crp::StickyCRP, x==0 ? crp.last : x, x==0, n)

--- a/src/statepriors.jl
+++ b/src/statepriors.jl
@@ -1,0 +1,27 @@
+# structs to represent state transition/occupation priors.
+
+abstract type StatePrior end
+
+struct ChineseRestaurantProcess
+    α::Float64
+    N::Vector{Float64}
+end
+
+ChineseRestaurantProcess(α::Float64) = ChineseRestaurantProcess(α, Vector{Float64}())
+
+candidates(crp::ChineseRestaurantProcess) = 1:length(crp.N)+1
+function add(crp::ChineseRestaurantProcess, x::Int, n::Float64=1.)
+    N = copy(crp.N)
+    if x == length(N)+1
+        push!(N, n)
+    else
+        N[x] += n
+    end
+    return ChineseRestaurantProcess(crp.α, N)
+end
+
+log_prior(crp::ChineseRestaurantProcess, x::Int) =
+    x == length(crp.N)+1 ? log(crp.α) : log(crp.N[x])
+
+marginal_log_prior(crp::ChineseRestaurantProcess) =
+    log_prior = sum(lgamma(n) for n in crp.N) + length(crp.N) * log(crp.α)

--- a/src/statepriors.jl
+++ b/src/statepriors.jl
@@ -11,6 +11,23 @@ the update).
 """
 function add(::StatePrior, state, n) end
 
+function Base.rand(p::StatePrior)
+    cands = candidates(p)
+    log_weights = log_prior.(p, cands)
+    log_weights .-= maximum(log_weights)
+    weights = Weights(exp.(log_weights))
+    sample(cands, weights)
+end
+
+function simulate(p::StatePrior, n::Int)
+    states = Int[]
+    for _ in 1:n
+        p, x = add(p, rand(p))
+        push!(states, x)
+    end
+    p, states
+end
+
 struct ChineseRestaurantProcess <: StatePrior
     α::Float64
     N::Vector{Float64}

--- a/src/statepriors.jl
+++ b/src/statepriors.jl
@@ -25,3 +25,68 @@ log_prior(crp::ChineseRestaurantProcess, x::Int) =
 
 marginal_log_prior(crp::ChineseRestaurantProcess) =
     log_prior = sum(lgamma(n) for n in crp.N) + length(crp.N) * log(crp.α)
+
+
+
+struct StickyCRP
+    α::Float64
+    ρ::Float64                  # probability of "sticking"
+    last::Int64
+    N::Vector{Float64}          # number of transitions to each from different
+    Nsame::Vector{Float64}      # number of transitions to same state
+end    
+
+StickyCRP(α::Float64, κ::Float64) = StickyCRP(α, κ, 0, Vector{Float64}(), Vector{Float64}())
+
+candidates(crp::StickyCRP) = 1:length(crp.N)+1
+function add(crp::StickyCRP, x::Int, n::Float64=1.0)
+    Nsame = crp.Nsame
+    if x == crp.last
+        Nsame = copy(crp.Nsame)
+        Nsame[x] += n
+        return StickyCRP(crp.α, crp.ρ, x, crp.N, Nsame)
+    elseif x == length(crp.N) + 1
+        return StickyCRP(crp.α, crp.ρ, x, push!(copy(crp.N), n), push!(copy(crp.Nsame), 0.))
+    else
+        N = copy(crp.N)
+        N[x] += n
+        return StickyCRP(crp.α, crp.ρ, x, N, crp.Nsame)
+    end
+end
+        
+        
+function log_prior(crp::StickyCRP, x::Int)
+    # prior is (1-ρ) * CRP prior, plus ρ * δ(x, crp.last)
+    #
+    # CRP prior is ∝ N_j if j∈1..K or α if j=K+1.
+    # the constant of proportionality is ∑N_j + α.
+    #
+    # total is (1-ρ)*N_j + ρ*δ(x, x_{n-1}) ∝ N_j + ρ/(1-ρ) δ(x, x_{n-1})
+    #
+    # p(s=1 | x_n = x_n-1) = p(s, x_n=x_n-1) / p(x_n=x_n-1)
+    #                      = p(x_n=x_n-1 | s) p(s) / p(x_n=x_n-1)
+    #
+    # p(s=1) = ρ
+    # p(x_n=x_n-1 | s=1) = 1
+    # p(x_n=x_n-1 | s=0) = ...?
+    #
+    # p(x_n = k | ρ, x_n-1) = ∑_s p(x_n=k | x_n-1, s) p(s | ρ)
+    #                       = δ(x_n, x_n-1) ρ + N_k/(N+α) (1-ρ)
+    #
+    # twist is that the N for CRP prior needs to adjust for the possibility that
+    # some self-transitions were due to not sticking.  given that there's a
+    # self-transition, the expected proportion of non-sticks is (1-ρ).  so the
+    # effective N is N + (1-ρ)Nsame.
+    #
+    # likewise the total count (for non-sticking) is N' = ∑N + (1-ρ)∑Nsame + α.
+    # the contribution if you don't stick is N'*(1-ρ)...
+    ρ = crp.ρ
+    if x == length(crp.N)+1
+        logp = log(crp.α) + log(1-ρ)
+    else
+    logp = log(crp.N[x] + crp.Nsame[x]*(1-ρ)) + log(1-ρ)
+    if x == crp.last
+        logp = logsumexp(logp, log(ρ))
+    end
+    return logp
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Base.Test
 
 @testset "Particles" begin
     include("component.jl")
+    include("statepriors.jl")
     include("particle.jl")
     include("fearnhead.jl")
     include("nix2.jl")

--- a/test/statepriors.jl
+++ b/test/statepriors.jl
@@ -1,0 +1,33 @@
+using Particles: ChineseRestaurantProcess, marginal_log_prior, candidates
+
+@testset "Priors on states" begin
+    @testset "Chinese restaurant process" begin
+
+        crp = ChineseRestaurantProcess(0.5)
+        @test crp.N == Float64[]
+        @test crp.α == 0.5
+
+        @test candidates(crp) == 1:1
+
+        crp1 = add(crp, 1)
+        @test crp1.N == [1.]
+        @test crp1.α == crp.α
+        @test candidates(crp1) == 1:2
+
+        
+
+        crp11 = add(crp1, 1)
+        @test crp11.N == [2.]
+
+        crp111 = add(crp11, 1, 0.5)
+        @test crp111.N == [2.5]
+
+        @test_throws BoundsError add(crp, 2)
+        @test_throws BoundsError add(crp1, 3)
+
+        crp1112 = add(crp111, 2)
+        @test crp1112.N == [2.5, 1.]
+        @test candidates(crp1112) == 1:3
+        
+    end
+end

--- a/test/statepriors.jl
+++ b/test/statepriors.jl
@@ -1,4 +1,4 @@
-using Particles: ChineseRestaurantProcess, marginal_log_prior, candidates
+using Particles: marginal_log_prior, log_prior, candidates, simulate, add
 
 @testset "Priors on states" begin
     @testset "Chinese restaurant process" begin

--- a/test/statepriors.jl
+++ b/test/statepriors.jl
@@ -30,4 +30,24 @@ using Particles: ChineseRestaurantProcess, marginal_log_prior, candidates
         @test candidates(crp1112) == 1:3
         
     end
+
+    @testset "Sticky CRP" begin
+
+        @testset "StickyCRP with ρ=0 == CRP" begin
+            scrp = StickyCRP(0.5, 0.0)
+            crp = ChineseRestaurantProcess(0.5)
+
+            srand(1)
+            scrp_sim, scrp_states = simulate(scrp, 100)
+            srand(1)
+            crp_sim, crp_states = simulate(crp, 100)
+
+            @test scrp_states == crp_states
+            @test scrp_sim.N == crp_sim.N
+
+            @test log_prior.(crp_sim, candidates(crp_sim)) ==
+                log_prior.(scrp_sim, candidates(scrp_sim))[2:end]
+
+        end
+    end
 end

--- a/test/statepriors.jl
+++ b/test/statepriors.jl
@@ -49,5 +49,16 @@ using Particles: ChineseRestaurantProcess, marginal_log_prior, candidates
                 log_prior.(scrp_sim, candidates(scrp_sim))[2:end]
 
         end
+
+        crp = StickyCRP(0.5, 0.9)
+        crp1, s1 = add(crp, 1, 0.5)
+        crp0, s0 = add(crp, 0, 0.5)
+
+        # state is same after `add` with sticky or not
+        @test s1 == s0
+        @test crp1.N == [0.5]
+        # ... but counts are not.
+        @test crp0.N == [0.]
+
     end
 end

--- a/test/statepriors.jl
+++ b/test/statepriors.jl
@@ -9,23 +9,23 @@ using Particles: ChineseRestaurantProcess, marginal_log_prior, candidates
 
         @test candidates(crp) == 1:1
 
-        crp1 = add(crp, 1)
+        crp1, _ = add(crp, 1)
         @test crp1.N == [1.]
         @test crp1.α == crp.α
         @test candidates(crp1) == 1:2
 
         
 
-        crp11 = add(crp1, 1)
+        crp11, _ = add(crp1, 1)
         @test crp11.N == [2.]
 
-        crp111 = add(crp11, 1, 0.5)
+        crp111, _ = add(crp11, 1, 0.5)
         @test crp111.N == [2.5]
 
         @test_throws BoundsError add(crp, 2)
         @test_throws BoundsError add(crp1, 3)
 
-        crp1112 = add(crp111, 2)
+        crp1112, _ = add(crp111, 2)
         @test crp1112.N == [2.5, 1.]
         @test candidates(crp1112) == 1:3
         


### PR DESCRIPTION
this replaces the chinese restaurant prior with a generalized `StatePrior` that tracks sufficient statistics and allows for custom/special states.  Also implements a "sticky CRP" prior, which adds a constant probability of "sticking", and staying on the same state.