### PR TITLE
represent putatives "lazily"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: julia
 os:
   - linux
 julia:
-  - 0.7
   - 1.0
   - nightly
 notifications:

--- a/bench/2d.jl
+++ b/bench/2d.jl
@@ -1,8 +1,8 @@
-using BenchmarkTools, 
-    Particles, 
-    Distributions, 
+using BenchmarkTools,
+    Particles,
+    Distributions,
     ConjugatePriors,
-    StaticArrays, 
+    StaticArrays,
     Compat,
     Random
 
@@ -15,29 +15,22 @@ truth = MixtureModel([MvNormal(-2 .* ones(2), Matrix(1.0I,2,2)),
                       MvNormal(2 .* ones(2), Matrix(1.0I,2,2))])
 y = [rand(truth) for _ in 1:100]
 
-function f(y)
-    prior = NormalInverseWishart(zeros(2), 0.1, Matrix(1.0I,2,2), 3.0)
+prior = NormalInverseWishart(zeros(2), 0.1, Matrix(1.0I,2,2), 3.0)
+
+function f(y, prior)
     stateprior = ChineseRestaurantProcess(1.)
     ps = ChenLiuParticles(100, prior, stateprior)
     filter!(ps, y, false)
 end
 
-f(y)
-@btime(f($y))
+f(y, prior)
+@btime(f($y, $prior))
 
+sprior = NormalInverseWishart(SVector{2}(zeros(2)), 0.1, cholesky(SMatrix{2,2}(1.0I)), 3.0)
 
-
-function g(y)
-    prior = NormalInverseWishart(zeros(2), 0.1, cholesky(SMatrix{2,2}(1.0I)), 3.0)
-    stateprior = ChineseRestaurantProcess(1.)
-    ps = ChenLiuParticles(100, prior, stateprior)
-    filter!(ps, y, false)
-end
-
-gps = g(y)
-@btime(g($y))
-
+f(y, sprior)
+@btime(f($y, $sprior))
 
 sy = SVector{2}.(y)
-g(sy)
-ps3 = @btime g($sy)
+f(sy, sprior)
+ps3 = @btime f($sy, $sprior)

--- a/bench/2d.jl
+++ b/bench/2d.jl
@@ -1,10 +1,15 @@
-using BenchmarkTools
-using Particles, Distributions, ConjugatePriors
+using BenchmarkTools, 
+    Particles, 
+    Distributions, 
+    ConjugatePriors,
+    StaticArrays, 
+    Compat,
+    Random
+
 using ConjugatePriors: NormalInverseWishart
-using StaticArrays
-using Compat
 using Compat.LinearAlgebra
 
+Random.seed!(100)
 
 truth = MixtureModel([MvNormal(-2 .* ones(2), Matrix(1.0I,2,2)),
                       MvNormal(2 .* ones(2), Matrix(1.0I,2,2))])

--- a/src/chenliu.jl
+++ b/src/chenliu.jl
@@ -33,13 +33,14 @@ function propogate_chenliu(p::P, y) where P<:AbstractParticle
     # posterior p( (z_1:n, j) | x_1:n+1 ) because they've been updated based on
     # the same ancestor, multiplying by
     # p( (z_1:n,j) | x_1:n+1) / p(z_1:n | x_1:n) ∝ p( (z_1:n,j) | x_1:n+1 )
-    next = wsample(ps, weight.(ps))
+    weights = weight.(ps)
+    next = instantiate(wsample(ps, weights))
     # now to update the weight.  we need it to be
     # w_n+1 = w_n × sum( p(z_1:n,j | x_1:n+1) / p(z_1:n | x_1:n) )
     # call the putative weight of particle j v_j.
     # v_j = w_n × p((z_1:n,j) | x_1:n+1) / p(z_1:n | x_1:n), so we just need to
     # add those up
-    return weight(next, sum(weight(pp) for pp in ps))
+    return weight(next, sum(weights))
 end
 
 """

--- a/src/fearnhead.jl
+++ b/src/fearnhead.jl
@@ -102,7 +102,7 @@ end
 Filter a single observation with the population of particles in `ps`.
 
 """
-function fit!(ps::FearnheadParticles{P}, y::Float64) where P
+function fit!(ps::FearnheadParticles{P}, y) where P
     # generate putative particles
     putative = collect(Iterators.flatten(putatives(p, y) for p in ps.particles))
     total_w = sum(weight(p) for p in putative)

--- a/src/fearnhead.jl
+++ b/src/fearnhead.jl
@@ -104,18 +104,13 @@ Filter a single observation with the population of particles in `ps`.
 """
 function fit!(ps::FearnheadParticles{P}, y::Float64) where P
     # generate putative particles
-    putative = P[]
-    for p in ps.particles
-        for pp in putatives(p,y)
-            push!(putative, pp)
-        end
-    end
+    putative = collect(Iterators.flatten(putatives(p, y) for p in ps.particles))
     total_w = sum(weight(p) for p in putative)
 
     M = length(putative)
     if M <= ps.N
         @debug "  M=$M: Fewer than N=$(ps.N) particles"
-        ps.particles = putative
+        ps.particles = instantiate.(putative)
     else
         # TODO: consider doing this all in place, see Fearnhead and Cliffor
         # 2003, Appendix C.  basic idea is to use an algorithm like
@@ -137,17 +132,15 @@ function fit!(ps::FearnheadParticles{P}, y::Float64) where P
                                       n_resamp,
                                       view(ws, ci:lastindex(ws)))
 
-        resize!(putative, n_resamp+ci-1)
+        resize!(ps.particles, n_resamp+ci-1)
 
-        for i in eachindex(putative)
+        for i in eachindex(ps.particles)
             new_w = (i < ci ? weight(putative[i]) : c) / total_w
-            putative[i] = weight(putative[i], new_w)
+            ps.particles[i] = weight(instantiate(putative[i]), new_w)
         end
-
-        ps.particles = putative
         @debug "  total weight: $(sum(weight(p) for p in ps.particles))"
     end
-    ps
+    return ps
 end
 
 function normalize_clusters!(ps::FearnheadParticles, method::Symbol)

--- a/test/particle.jl
+++ b/test/particle.jl
@@ -1,13 +1,29 @@
+using Particles: candidates, instantiate
+
 @testset "Updating particles" begin
     
+    @testset "putatives vs. direct fit" begin
+        p = InfiniteParticle(NormalInverseChisq(0., 1., 0.1, 0.1), 2.0)
+        ys = rand(10)
+
+        global ps_put = [p]
+        global ps_fit = [p]
+        for y in ys
+            ps_put = reduce(vcat, Particles.instantiate.(putatives(p, y)) for p in ps_put)
+            ps_fit = reduce(vcat, fit.(Ref(p), y, candidates(p.stateprior)) for p in ps_fit)
+            @test components.(ps_put) == components.(ps_fit)
+        end
+    end
+        
     @testset "Weight update" begin
         # weights should remain proportional to the conditional posterior p(z|y,x)
-        p = InfiniteParticle((0., 1., 0.1, 0.1), 2.0)
+        p = InfiniteParticle(NormalInverseChisq(0., 1., 0.1, 0.1), 2.0)
         ps = [p]
         for x in 1.:5.
-            ps = vcat(collect.(putatives.(ps, x))...)
+            ps = Particles.instantiate.(vcat(collect.(putatives.(ps, x))...))
             @test weight.(ps) ≈ marginal_posterior.(ps)
         end
     end
+
     
 end


### PR DESCRIPTION
We can avoid some copies by just representing putatives with their weights (and also the one component that was copied).  Then when a putative is accepted, the vectors are copied to update.